### PR TITLE
crawler: update crawler for new schemas

### DIFF
--- a/crawler/umamusume.py
+++ b/crawler/umamusume.py
@@ -15,30 +15,11 @@ from translator import translate
 from utils import get_gamewith_id, download_image
 
 
-
-def repl():
-    string = '''                  <div class="uma_choice_table">
-                    <table>
-                      <tr>
-                        <th>バテないようにスタミナをつけよう！</th>
-                        <td>スタミナ+10<br />スキルPt+15</td>
-                      </tr>
-                      <tr>
-                        <th>ライバルを追い抜かすコツを掴もう！</th>
-                        <td>『直線巧者』のヒントLv+1</td>
-                      </tr>
-                    </table>
-                  </div>
-'''
-    soup = BeautifulSoup(string, "lxml")
-
 def get_umamusume_event_choice(soup: BeautifulSoup) -> Dict:
     results = {}
     trs: List[BeautifulSoup] = soup.find_all("tr")
-    print(f"    soup: {soup}")
     nonempty_trs = filter(lambda tr: tr.find("th") and tr.find("td"), trs)
     for tr in nonempty_trs:
-        print(tr)
         key = tr.find("th").text
         value = tr.find("td").get_text(separator="\n")
         results[key] = value
@@ -65,10 +46,8 @@ def get_umamusume_event(soup: BeautifulSoup) -> List[Dict]:
         filter(lambda h3: h3.text in to_scrape_events, soup.find_all("h3"))
     )
     for to_scrape_h3_tag in to_scrape_event_tags:
-        print(f"to_scrape_h3_tag: {to_scrape_h3_tag}")
         uma_choice_tables = get_uma_choice_table_for_h3(to_scrape_h3_tag)
         for div in uma_choice_tables:
-            print(f"    div: {div}")
             title = div.find_previous_sibling("h4").text
             event_choice = get_umamusume_event_choice(div)
             results.append({"title": title, "event_choice": event_choice})

--- a/crawler/umamusume.py
+++ b/crawler/umamusume.py
@@ -3,7 +3,11 @@ from typing import Dict, List
 import requests
 from bs4 import BeautifulSoup
 
-from crawler.skill import crawl_umamusume_skill, skill_name_polyfill, get_uma_skill_category
+from crawler.skill import (
+    crawl_umamusume_skill,
+    skill_name_polyfill,
+    get_uma_skill_category,
+)
 from database import db_session
 from models import Skill, UmaSkill
 from models.uma import Umamusume, UmaEvent, UmaEventChoice
@@ -11,70 +15,104 @@ from translator import translate
 from utils import get_gamewith_id, download_image
 
 
+
+def repl():
+    string = '''                  <div class="uma_choice_table">
+                    <table>
+                      <tr>
+                        <th>バテないようにスタミナをつけよう！</th>
+                        <td>スタミナ+10<br />スキルPt+15</td>
+                      </tr>
+                      <tr>
+                        <th>ライバルを追い抜かすコツを掴もう！</th>
+                        <td>『直線巧者』のヒントLv+1</td>
+                      </tr>
+                    </table>
+                  </div>
+'''
+    soup = BeautifulSoup(string, "lxml")
+
 def get_umamusume_event_choice(soup: BeautifulSoup) -> Dict:
     results = {}
-    trs: List[BeautifulSoup] = soup.find_all('tr')
-    for tr in trs:
-        key = tr.find('th').text
-        value = tr.find('td').get_text(separator="\n")
+    trs: List[BeautifulSoup] = soup.find_all("tr")
+    print(f"    soup: {soup}")
+    nonempty_trs = filter(lambda tr: tr.find("th") and tr.find("td"), trs)
+    for tr in nonempty_trs:
+        print(tr)
+        key = tr.find("th").text
+        value = tr.find("td").get_text(separator="\n")
         results[key] = value
 
     return results
 
 
 def get_umamusume_event(soup: BeautifulSoup) -> List[Dict]:
-    results = []
-    bs_divs: List[BeautifulSoup] = soup.find_all('div', {"class": "uma_choice_table"})
-    for div in bs_divs:
-        title = div.find_previous_sibling('h4').text
-        event_choice = get_umamusume_event_choice(div)
-        results.append({
-            'title': title,
-            'event_choice': event_choice
-        })
+    def get_uma_choice_table_for_h3(h3):
+        """find consecutively occurring uma_choice_tables starting from the given h3, stopping when a new h3 is hit."""
+        acc = []
+        current = h3.find_next_sibling(name="div", attrs={"class": "uma_choice_table"})
+        while current.name != "h3":
+            if current.name == "div" and current.attrs == {
+                "class": ["uma_choice_table"]
+            }:
+                acc.append(current)
+            current = current.find_next_sibling()
+        return acc
 
-        if div.find_next_sibling().name == "h3":
-            break
+    to_scrape_events = ["通常イベント(選択肢あり)", "勝負服イベント", "お出かけイベント", "レース後イベント"]
+    results = []
+    to_scrape_event_tags = list(
+        filter(lambda h3: h3.text in to_scrape_events, soup.find_all("h3"))
+    )
+    for to_scrape_h3_tag in to_scrape_event_tags:
+        print(f"to_scrape_h3_tag: {to_scrape_h3_tag}")
+        uma_choice_tables = get_uma_choice_table_for_h3(to_scrape_h3_tag)
+        for div in uma_choice_tables:
+            print(f"    div: {div}")
+            title = div.find_previous_sibling("h4").text
+            event_choice = get_umamusume_event_choice(div)
+            results.append({"title": title, "event_choice": event_choice})
+
     return results
 
 
 def get_umamusume_info_table(soup: BeautifulSoup) -> Dict:
     results = {}
-    bs_table = soup.find_all('table')[1]
-    for row in bs_table.findAll('tr'):
-        key = row.find('th').text
-        value = row.find('td').text
+    bs_table = soup.find_all("table")[1]
+    for row in bs_table.findAll("tr"):
+        key = row.find("th").text
+        value = row.find("td").text
         results[key] = value
 
     return results
 
 
 def get_umamusume_name(soup: BeautifulSoup) -> str:
-    h3 = soup.find('h3').text
-    return h3.replace('の評価', '')
+    h3 = soup.find("h3").text
+    return h3.replace("の評価", "")
 
 
 def get_umamusume_illust_url(soup: BeautifulSoup) -> str:
     # before https://img.gamewith.jp/article_tools/uma-musume/gacha/ikusei_main_30.png
     # after https://img.gamewith.jp/article_tools/uma-musume/gacha/i_30.png
-    illust = soup.find('h3').find_next_sibling('img')['data-original']
-    index = illust.split('/')[-1].replace('ikusei_main_', '').replace('.png', '')
+    illust = soup.find("h3").find_next_sibling("img")["data-original"]
+    index = illust.split("/")[-1].replace("ikusei_main_", "").replace(".png", "")
     return f"https://img.gamewith.jp/article_tools/uma-musume/gacha/i_{index}.png"
 
 
 def get_rare_degree(value: str) -> int:
-    return int(value.replace('星', ''))
+    return int(value.replace("星", ""))
 
 
 def get_related_skill_from_db(url: str, uma: Umamusume):
     relation_skills = crawl_umamusume_skill(url)
     for relation_skill in relation_skills:
-        relation_skill_name = skill_name_polyfill(relation_skill['name'])
+        relation_skill_name = skill_name_polyfill(relation_skill["name"])
         skill = Skill.query.filter(Skill.name == relation_skill_name).first()
         if not skill:
             print(f"skill not exists")
             continue
-        category = get_uma_skill_category(relation_skill['category'])
+        category = get_uma_skill_category(relation_skill["category"])
         cs = UmaSkill(category=category)
         cs.uma = uma
         skill.uma_tachi.append(cs)
@@ -85,7 +123,7 @@ def crawl_new_umamusume(uri: str, update: bool = False):
     if r.status_code != 200:
         return False
 
-    soup = BeautifulSoup(r.text, 'lxml')
+    soup = BeautifulSoup(r.text, "lxml")
     gamewith_id = get_gamewith_id(uri)
     illust = get_umamusume_illust_url(soup)
     filename = download_image(illust)
@@ -94,23 +132,30 @@ def crawl_new_umamusume(uri: str, update: bool = False):
     umamusume = get_umamusume_info_table(soup)
     umamusume_events = get_umamusume_event(soup)
 
-    if '名称' in umamusume:
-        second_name = umamusume['名称']
+    if "名称" in umamusume:
+        second_name = umamusume["名称"]
     else:
-        second_name = umamusume['固有二つ名']
+        second_name = umamusume["固有二つ名"]
 
-    umamusume_model = Umamusume(uma_name=uma_name,
-                                uma_name_kr=uma_name,
-                                second_name=second_name,
-                                second_name_kr=second_name,
-                                uma_image=filename,
-                                gamewith_wiki_id=gamewith_id,
-                                rare_degree=get_rare_degree(umamusume['初期レア']))
+    umamusume_model = Umamusume(
+        uma_name=uma_name,
+        uma_name_kr=uma_name,
+        second_name=second_name,
+        second_name_kr=second_name,
+        uma_image=filename,
+        gamewith_wiki_id=gamewith_id,
+        rare_degree=get_rare_degree(umamusume["初期レア"]),
+    )
 
-    model_from_db = db_session.query(Umamusume).filter_by(
+    model_from_db = (
+        db_session.query(Umamusume)
+        .filter_by(
             second_name=umamusume_model.second_name,
             uma_name=umamusume_model.uma_name,
-            rare_degree=umamusume_model.rare_degree).first()
+            rare_degree=umamusume_model.rare_degree,
+        )
+        .first()
+    )
 
     if model_from_db and update:
         umamusume_model = model_from_db
@@ -118,34 +163,45 @@ def crawl_new_umamusume(uri: str, update: bool = False):
         return False
 
     db_session.add(umamusume_model)
-    print('get umamusume')
+    print("get umamusume")
     for event in umamusume_events:
-        umamusume_event_model = UmaEvent(title=event['title'],
-                                         title_kr=event['title'],
-                                         umamusume=umamusume_model)
+        umamusume_event_model = UmaEvent(
+            title=event["title"], title_kr=event["title"], umamusume=umamusume_model
+        )
 
         if umamusume_model.uuid:
-            model_from_db = db_session.query(UmaEvent).filter_by(
-                title=umamusume_event_model.title,
-                umamusume=umamusume_event_model.umamusume).first()
+            model_from_db = (
+                db_session.query(UmaEvent)
+                .filter_by(
+                    title=umamusume_event_model.title,
+                    umamusume=umamusume_event_model.umamusume,
+                )
+                .first()
+            )
 
         if model_from_db and not update:
             continue
 
         db_session.add(umamusume_event_model)
-        print('get event')
+        print("get event")
 
-        for key, value in event['event_choice'].items():
-            umamusume_event_choices = UmaEventChoice(title=key,
-                                                     title_kr=key,
-                                                     effect=value,
-                                                     effect_kr=value,
-                                                     event=umamusume_event_model)
+        for key, value in event["event_choice"].items():
+            umamusume_event_choices = UmaEventChoice(
+                title=key,
+                title_kr=key,
+                effect=value,
+                effect_kr=value,
+                event=umamusume_event_model,
+            )
             if umamusume_event_model.uuid:
-                model_from_db = db_session.query(UmaEventChoice).filter_by(
-                    title=umamusume_event_choices.title,
-                    event_id=umamusume_event_choices.event_id,
-                ).first()
+                model_from_db = (
+                    db_session.query(UmaEventChoice)
+                    .filter_by(
+                        title=umamusume_event_choices.title,
+                        event_id=umamusume_event_choices.event_id,
+                    )
+                    .first()
+                )
 
             if not model_from_db:
                 db_session.add(umamusume_event_choices)

--- a/tests/crawler/umamusume_test.py
+++ b/tests/crawler/umamusume_test.py
@@ -6,66 +6,130 @@ from crawler.umamusume import *
 
 
 @pytest.fixture(scope="module")
-def soup():
+def soup1():
     r = requests.get("https://gamewith.jp/uma-musume/article/show/266048")
     if r.status_code != 200:
         raise Exception("Gamewith server seems down")
-    yield BeautifulSoup(r.text, 'lxml')
+    yield BeautifulSoup(r.text, "lxml")
 
 
-def test_umamusume_info_table(soup):
-    data = get_umamusume_info_table(soup)
+@pytest.fixture(scope="module")
+def soup2():
+    r = requests.get("https://gamewith.jp/uma-musume/article/show/292755")
+    if r.status_code != 200:
+        raise Exception("Gamewith server seems down")
+    yield BeautifulSoup(r.text, "lxml")
+
+
+@pytest.fixture(scope="module")
+def soup3():
+    r = requests.get("https://gamewith.jp/uma-musume/article/show/257397")
+    if r.status_code != 200:
+        raise Exception("Gamewith server seems down")
+    yield BeautifulSoup(r.text, "lxml")
+
+
+@pytest.fixture(scope="module")
+def soup4():
+    r = requests.get("https://gamewith.jp/uma-musume/article/show/257412")
+    if r.status_code != 200:
+        raise Exception("Gamewith server seems down")
+    yield BeautifulSoup(r.text, "lxml")
+
+
+def test_umamusume_info_table(soup1):
+    data = get_umamusume_info_table(soup1)
     expect = {
         "初期レア": "星3",
         "名称": "エンド・オブ・スカイ",
         "入手方法": "ウマ娘ガチャから入手",
         "固有二つ名": "名優",
         "おすすめ距離": "長距離、中距離",
-        "おすすめ脚質": "逃げ、先行"
+        "おすすめ脚質": "逃げ、先行",
     }
     assert data == expect
 
 
-def test_umamusume_name(soup):
-    actual = get_umamusume_name(soup)
+def test_umamusume_name(soup1):
+    actual = get_umamusume_name(soup1)
     expect = "メジロマックイーン(新衣装)"
     assert actual == expect
 
 
-def test_umamusume_event(soup):
-    actual = get_umamusume_event(soup)
+# 通常イベント(選択肢あり)
+# 勝負服イベント
+# お出かけイベント
+# レース後イベント
+
+
+def test_umamusume_event1(soup1):
+    # https://gamewith.jp/uma-musume/article/show/266048
+    #
+    actual = get_umamusume_event(soup1)
+    expect = {"title": "孤島の女王", "event_choice": {"食料": "スピード+10", "体力": "スタミナ+10"}}
+    assert actual[0] == expect
+    assert len(actual) == 12 + 3 + 5 + 10
+
+
+def test_umamusume_event2(soup2):
+    # https://gamewith.jp/uma-musume/article/show/292755
+    actual = get_umamusume_event(soup2)
     expect = {
-        "title": "孤島の女王",
-        "event_choice": {
-            "食料": "スピード+10",
-            "体力": "スタミナ+10"
-        }
+        "title": "呪いのカメラ",
+        "event_choice": {"現代のカメラは大丈夫": "賢さ+10", "魂を取り返せばいい": "スキルPt+30"},
     }
     assert actual[0] == expect
-    assert len(actual) == 24
+    assert len(actual) == 12 + 3 + 5 + 15
+
+
+def test_umamusume_event3(soup3):
+    # https://gamewith.jp/uma-musume/article/show/257397
+    actual = get_umamusume_event(soup3)
+    expect = {
+        "title": "マヤちんのレース講座☆",
+        "event_choice": {
+            "バテないようにスタミナをつけよう！": "スタミナ+10\nスキルPt+15",
+            "ライバルを追い抜かすコツを掴もう！": "『直線巧者』のヒントLv+1",
+        },
+    }
+    assert actual[0] == expect
+    assert len(actual) == 12 + 3 + 5 + 12
+
+
+def test_umamusume_event4(soup4):
+    # https://gamewith.jp/uma-musume/article/show/257412
+    actual = get_umamusume_event(soup4)
+    expect = {
+        "title": "昼下がりの恩返し",
+        "event_choice": {"食べることを楽しもう！": "体力+5\n賢さ+5", "何も言う事はない！": "『ペースキープ』のヒントLv+1"},
+    }
+    assert actual[0] == expect
+    assert len(actual) == 12 + 3 + 5 + 10
 
 
 def test_umamusume_event_choice():
-    fixture = '<div class="uma_choice_table">' \
-              '<table><tr><th>やった、やったぞーっ！！</th>' \
-              '<td>体力-15<br/>5種ステータスからランダムに1種を+5<br/>スキルPt+30</td></tr>' \
-              '<tr><th>更なる高みを目指そう！</th>' \
-              '<td>体力-5~20<br/>5種ステータスからランダムに1種を+5~10<br/>スキルPt+30~45</td></tr>' \
-              '</table></div>'
+    fixture = (
+        '<div class="uma_choice_table">'
+        "<table><tr><th>やった、やったぞーっ！！</th>"
+        "<td>体力-15<br/>5種ステータスからランダムに1種を+5<br/>スキルPt+30</td></tr>"
+        "<tr><th>更なる高みを目指そう！</th>"
+        "<td>体力-5~20<br/>5種ステータスからランダムに1種を+5~10<br/>スキルPt+30~45</td></tr>"
+        "</table></div>"
+    )
 
-    soup = BeautifulSoup(fixture, 'lxml')
-    actual = get_umamusume_event_choice(soup)
+    soup1 = BeautifulSoup(fixture, "lxml")
+    actual = get_umamusume_event_choice(soup1)
     expect = {
         "やった、やったぞーっ！！": "体力-15\n5種ステータスからランダムに1種を+5\nスキルPt+30",
-        "更なる高みを目指そう！": "体力-5~20\n5種ステータスからランダムに1種を+5~10\nスキルPt+30~45"
+        "更なる高みを目指そう！": "体力-5~20\n5種ステータスからランダムに1種を+5~10\nスキルPt+30~45",
     }
 
     assert actual == expect
 
 
-def test_umamusume_illust_url(soup):
-    actual = get_umamusume_illust_url(soup)
-    expect = 'https://img.gamewith.jp/article_tools/uma-musume/gacha/i_30.png'
+def test_umamusume_illust_url(soup1):
+    actual = get_umamusume_illust_url(soup1)
+    expect = "https://img.gamewith.jp/article_tools/uma-musume/gacha/i_30.png"
 
     assert actual == expect
 


### PR DESCRIPTION
두 가지를 바꾸었습니다:

- `get_umamusume_event_choice` 에서 빈 table row 무시
- `get_umamusume_event` 에서 통상(옵션있음), 승부복, 외출, 경주후 이벤트까지 가져오기

테스트 변경:

- 원래 있던 `soup`을 `soup1`로 변경, `soup2`, `soup3`, `soup4` 추가

기타:

- `black`으로 포맷팅